### PR TITLE
Relax dependency constraints

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 00bc325943343df59f0c775c11bd86606cbcc3d20a4391a32c8bac58b6926623
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install --no-deps --ignore-installed . -vvv
 
@@ -22,21 +22,20 @@ requirements:
     - pip
     - setuptools_scm
     - numpy >=1.16
-    - pyarrow ==0.15.0
+    - pyarrow ==0.15.0.*
     - packaging >=20.0
     - rbc ==0.2.2
   run:
     - python >=3
     - setuptools
     - {{ pin_compatible('numpy') }}
-    - pyarrow ==0.15.0
+    - pyarrow ==0.15.0.*
     - pandas >=0.25,<0.26
     - six
+    - shapely
     - sqlalchemy >=1.3
     - thrift 0.13.*
     - packaging >=20.0
-    - geopandas
-    - libtiff ==4.0.10
     - rbc ==0.2.2
     - requests
 


### PR DESCRIPTION
Conda was failing to solve dependencies when installing pymapd
without a version specifier and it was giving up early to deliver
an old pympad version.

We can make geopandas and its libtiff pin optional for now.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
